### PR TITLE
Fix Statistik missing days and show empty data

### DIFF
--- a/StatistikView.swift
+++ b/StatistikView.swift
@@ -73,12 +73,28 @@ struct AttendanceView: View {
     @State private var isLoading = true
     @State private var selectedWeekIndex = 0
 
+    private let weekDays = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+
     private let chartHeight: CGFloat = 150
 
     private var first: Statistic? { stats.first }
 
     private var weeks: [[DayStat]] {
         first?.weekly_summary.map { $0.days } ?? []
+    }
+
+    private var completedWeeks: [[DayStat]] {
+        let filled = weeks.map { week -> [DayStat] in
+            guard !week.isEmpty else { return [] }
+            var dict = Dictionary(uniqueKeysWithValues: week.map { ($0.day, $0) })
+            return weekDays.map { day in
+                dict[day] ?? DayStat(day: day, locationId: 0, locationName: "", hours: 0)
+            }
+        }
+        if filled.allSatisfy({ $0.isEmpty }) {
+            return [weekDays.map { DayStat(day: $0, locationId: 0, locationName: "", hours: 0) }]
+        }
+        return filled
     }
 
     private var checkInTime: String {
@@ -119,7 +135,7 @@ struct AttendanceView: View {
     }
 
     private var maxHours: Double {
-        let week = weeks[safe: selectedWeekIndex] ?? []
+        let week = completedWeeks[safe: selectedWeekIndex] ?? []
         return max(1, week.map { $0.hours }.max() ?? 1)
     }
 
@@ -188,9 +204,9 @@ struct AttendanceView: View {
             }
 
             TabView(selection: $selectedWeekIndex) {
-                ForEach(weeks.indices, id: \.self) { idx in
+                ForEach(completedWeeks.indices, id: \.self) { idx in
                     HStack(alignment: .bottom, spacing: 16) {
-                        ForEach(weeks[idx]) { stat in
+                        ForEach(completedWeeks[idx]) { stat in
                             VStack(spacing: 6) {
                                 Text(formatHours(stat.hours))
                                     .font(.caption2).foregroundColor(.gray)


### PR DESCRIPTION
## Summary
- fill missing weekdays with zero-hour bars
- display placeholder week if statistics are empty

## Testing
- `swiftc StatistikView.swift -o /tmp/out` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6887c40e0cd88326a63205f56ae8dc6b